### PR TITLE
Remove GitHub stats image from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ I’m currently open to senior or lead remote roles where ownership, autonomy, a
 <!--- -- GitHub Stats ------------------------------------------------------------------------------------------------------------------------------------ -->
 <!--- ------------------------------------------------------------------------------------------------------------------------------------------------------ -->
 
-| ![Kilama Elie github stats](https://github-readme-stats.vercel.app/api?username=kilamaelie\&rank_icon=percentile&show_icons=true&theme=tokyonight&show=reviews&bg_color=fff&title_color=0a1931&icon_color=0a1931&text_color=0A0209&border_color=0A0209&border_radius=8) | ![Kilama Elie GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=kilamaelie&theme=tokyonight&theme=icegray&border_radius=8) |
+| ![Kilama Elie GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=kilamaelie&theme=tokyonight&theme=icegray&border_radius=8) |
 | -- | -- |
 
 <hr>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GitHub Stats section to display only streak statistics, removing the GitHub stats card visualization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kilamaelie/kilamaelie/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->